### PR TITLE
get rid of /data/resource-cache to fix bootloop

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Or...
   - Go to your recovery,
   - Clear Cache and Dalvik
   - Go to file manager,
-  - Go to /data/resource-cache,
-  - Delete overlay.list;
+  - Remove folder /data/resource-cache
+  - reboot
   - Done.
   - If still bootloop, just force restart by holding power button.
 


### PR DESCRIPTION
If this folder still exist, It will not be able to boot into system because of following error
set_policy_failed:/data/resource-cache